### PR TITLE
Revert "Bump @discordjs/voice from 0.11.0 to 0.13.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@discordjs/opus": "^0.9.0",
-        "@discordjs/voice": "^0.13.0",
+        "@discordjs/voice": "^0.11.0",
         "axios": "^1.1.3",
         "discord.js": "^14.6.0",
         "favcolor": "^0.2.0",
@@ -113,15 +113,15 @@
       }
     },
     "node_modules/@discordjs/voice": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/voice/-/voice-0.13.0.tgz",
-      "integrity": "sha512-ZzwDmVINaLgkoDUeTJfpN9TkjINMLfTVoLMtEygm0YC5jTTw7AvKGqhc+Ae/2kNLywd0joyFVNrLp94yCkQ9SA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/voice/-/voice-0.11.0.tgz",
+      "integrity": "sha512-6+9cj1dxzBJm7WJ9qyG2XZZQ8rcLl6x2caW0C0OxuTtMLAaEDntpb6lqMTFiBg/rDc4Rd59g1w0gJmib33CuHw==",
       "dependencies": {
         "@types/ws": "^8.5.3",
-        "discord-api-types": "^0.37.12",
+        "discord-api-types": "^0.36.2",
         "prism-media": "^1.3.4",
         "tslib": "^2.4.0",
-        "ws": "^8.9.0"
+        "ws": "^8.8.1"
       },
       "engines": {
         "node": ">=16.9.0"
@@ -141,11 +141,6 @@
       "engines": {
         "node": ">=12.0.0"
       }
-    },
-    "node_modules/@discordjs/voice/node_modules/discord-api-types": {
-      "version": "0.37.14",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.14.tgz",
-      "integrity": "sha512-byBH7SfDCMJwxdqeS8k5sihltH88/YPhuwx+vF2cftSxFLdxyHyU/ZxDL3bq+LB2c4ls/TymE76/ISlLfniUXg=="
     },
     "node_modules/@discordjs/voice/node_modules/prism-media": {
       "version": "1.3.4",
@@ -1475,15 +1470,15 @@
       "integrity": "sha512-e7d+PaTLVQav6rOc2tojh2y6FE8S7REkqLldq1XF4soCx74XB/DIjbVbVLtBemf0nLW77ntz0v+o5DytKwFNLQ=="
     },
     "@discordjs/voice": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@discordjs/voice/-/voice-0.13.0.tgz",
-      "integrity": "sha512-ZzwDmVINaLgkoDUeTJfpN9TkjINMLfTVoLMtEygm0YC5jTTw7AvKGqhc+Ae/2kNLywd0joyFVNrLp94yCkQ9SA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/voice/-/voice-0.11.0.tgz",
+      "integrity": "sha512-6+9cj1dxzBJm7WJ9qyG2XZZQ8rcLl6x2caW0C0OxuTtMLAaEDntpb6lqMTFiBg/rDc4Rd59g1w0gJmib33CuHw==",
       "requires": {
         "@types/ws": "^8.5.3",
-        "discord-api-types": "^0.37.12",
+        "discord-api-types": "^0.36.2",
         "prism-media": "^1.3.4",
         "tslib": "^2.4.0",
-        "ws": "^8.9.0"
+        "ws": "^8.8.1"
       },
       "dependencies": {
         "@discordjs/opus": {
@@ -1496,11 +1491,6 @@
             "@discordjs/node-pre-gyp": "^0.4.4",
             "node-addon-api": "^5.0.0"
           }
-        },
-        "discord-api-types": {
-          "version": "0.37.14",
-          "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.14.tgz",
-          "integrity": "sha512-byBH7SfDCMJwxdqeS8k5sihltH88/YPhuwx+vF2cftSxFLdxyHyU/ZxDL3bq+LB2c4ls/TymE76/ISlLfniUXg=="
         },
         "prism-media": {
           "version": "1.3.4",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/DjesonPV/PotatOSKastanie#readme",
   "dependencies": {
     "@discordjs/opus": "^0.9.0",
-    "@discordjs/voice": "^0.13.0",
+    "@discordjs/voice": "^0.11.0",
     "axios": "^1.1.3",
     "discord.js": "^14.6.0",
     "favcolor": "^0.2.0",


### PR DESCRIPTION
Reverts DjesonPV/Discord-PotatOS#31

Bug in 0.13.0 which break the use of ES6 modules/mjs
Needs to wait ^0.13.1 